### PR TITLE
Add support for deeplinking into Appcues from Flutter

### DIFF
--- a/android/src/main/kotlin/com/appcues/flutter/AppcuesFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/AppcuesFlutterPlugin.kt
@@ -2,6 +2,8 @@ package com.appcues.flutter
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.annotation.NonNull
 import com.appcues.Appcues
 import com.appcues.LoggingLevel
@@ -157,6 +159,22 @@ class AppcuesFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
                 } else {
                     result.badArgs("experienceId")
+                }
+            }
+            "didHandleURL" -> {
+                val url = call.argument<String>("url")
+                if (url != null) {
+                    val activity = this.activity
+                    if (activity != null) {
+                        val uri = Uri.parse(url)
+                        val intent = Intent(Intent.ACTION_VIEW)
+                        intent.data = uri
+                        result.success(implementation.onNewIntent(activity, intent))
+                    } else {
+                        result.error("no-activity", "unable to handle the URL, no current running Activity found", null)
+                    }
+                } else {
+                    result.badArgs("url")
                 }
             }
             else -> result.notImplemented()

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -27,6 +27,14 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Deep linking -->
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+            <intent-filter>
+                <data android:scheme="appcues-APPCUES_APPLICATION_ID" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -4,11 +4,14 @@ PODS:
     - Appcues
     - Flutter
   - Flutter (1.0.0)
+  - uni_links (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - Appcues (= 1.0.0-beta.3)
   - appcues_flutter (from `.symlinks/plugins/appcues_flutter/ios`)
   - Flutter (from `Flutter`)
+  - uni_links (from `.symlinks/plugins/uni_links/ios`)
 
 SPEC REPOS:
   trunk:
@@ -19,11 +22,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/appcues_flutter/ios"
   Flutter:
     :path: Flutter
+  uni_links:
+    :path: ".symlinks/plugins/uni_links/ios"
 
 SPEC CHECKSUMS:
   Appcues: e00f922a9e2ef99ffc55a2bc534c97c55d131d4d
   appcues_flutter: 433896d7f81185e23f23b41c49770ddc86f83d1a
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
 
 PODFILE CHECKSUM: d0f87b867e8dcd9977c0f5a392126c4d13264321
 

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,18 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>appcues-APPCUES_APPLICATION_ID</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,6 +81,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -116,6 +128,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -163,6 +182,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  uni_links:
+    dependency: "direct main"
+    description:
+      name: uni_links
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.1"
+  uni_links_platform_interface:
+    dependency: transitive
+    description:
+      name: uni_links_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  uni_links_web:
+    dependency: transitive
+    description:
+      name: uni_links_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
 
+  # Adds support for detecting URIs from custom app scheme deeplinks
+  uni_links: ^0.5.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/ios/Classes/SwiftAppcuesFlutterPlugin.swift
+++ b/ios/Classes/SwiftAppcuesFlutterPlugin.swift
@@ -105,6 +105,12 @@ public class SwiftAppcuesFlutterPlugin: NSObject, FlutterPlugin {
             } else {
                 result(missingArgs(names: "experienceId"))
             }
+        case "didHandleURL":
+            if let urlString = call["url"], let url = URL(string: urlString) {
+                result(implementation.didHandleURL(url))
+            } else {
+                result(missingArgs(names: "url"))
+            }
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -63,4 +63,8 @@ class AppcuesFlutter {
   static Future<bool> show(String experienceId) async {
     return await _channel.invokeMethod('show', {'experienceId': experienceId});
   }
+
+  static Future<bool> didHandleURL(Uri url) async {
+    return await _channel.invokeMethod('didHandleURL', {'url': url.toString()});
+  }
 }


### PR DESCRIPTION
stacks on #3 

At a high level, we need to intercept some URI coming into the app, and pass it off to the Appcues plugin wrapper - the string - in the new didHandleURL function. That part and the wrapper is pretty straightforward.

Then, to demonstrate and test in the example app, we need a way to intercept incoming deeplinks in the Flutter applications, and pass into our wrapper. Flutter provides some docs on [Deep linking](https://docs.flutter.dev/development/ui/navigation/deep-linking)

There appear to be at least 5 ways that deep linking has been handled and evolving over time. It's not totally clear to me yet which is most straightforward for us, for demo purposes.  And this may evolve as we build our test app to be a bit more robust.

1. It appears the [original mechanism](https://medium.com/flutter-community/deep-links-and-flutter-applications-how-to-handle-them-properly-8c9865af9283) was based on purely native code handling, then communicating back to Flutter via MethodChannels

2. There are ways to define a MaterialApp that can declare [routes](https://api.flutter.dev/flutter/material/MaterialApp/routes.html) or an [onGenerateRoute](https://api.flutter.dev/flutter/material/MaterialApp/onGenerateRoute.html) functionalty that appear to be addressing the topic of in-app routing, but perhaps not our deeplinks that need to have the URI sent over to the Appcues plugin

3. There are references to "Using Navigator" [in the main doc](https://docs.flutter.dev/development/ui/navigation/deep-linking#behavior) though I have not yet found details of what that means in the implementation.

4. There is a seemingly newer and more sophisticated concept of a [Router](https://api.flutter.dev/flutter/widgets/Router-class.html) widget, and a thorough [sample app demonstration](https://github.com/flutter/samples/tree/main/navigation_and_routing) of this.  Like #2, this appears highly focused on the in-app routing to pages and not directly on our use case of passing the URI elsewhere.

5. There a library called [uni_links](https://pub.dev/packages/uni_links) that appears to have high popularity across other blogs and StackOverflow posts, and it provides a mechanism to abstract away a lot of the details of #1, it appears, and get easy access to the URI links in the Flutter code.


I took path #5 to start, since it was just a few lines of code and allowed me to intercept and pass the links through successfully.  This seems ok to start, though I would like to investigate #4 more as part of building out more of the sample app, and see if this is appropriate to use and could help make our demo agnostic of any other plugin packages.

In any case, the SDK wrapper portion is complete and fairly simple here, and the host application has to have _some way_ to get access to link data and pass it through.