### PR TITLE
Enable Google Play upload

### DIFF
--- a/example/android/fastlane/Fastfile
+++ b/example/android/fastlane/Fastfile
@@ -27,12 +27,13 @@ platform :android do
       }
     )
 
-    # upload_to_play_store(
-    #   track: 'internal', 
-    #   skip_upload_apk: true, 
-    #   json_key_data: ENV["PLAY_STORE_API_KEY"],
-    #   rollout: '1'
-    # )
+    upload_to_play_store(
+      aab: '../build/app/outputs/bundle/release/app-release.aab',
+      track: 'internal', 
+      skip_upload_apk: true, 
+      json_key_data: ENV["PLAY_STORE_API_KEY"],
+      rollout: '1'
+    )
   end
 
 end

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -62,7 +62,7 @@ class _MyAppState extends State<MyApp> {
   Future<bool> _initializeAppcues() async {
     AppcuesFlutterOptions options = AppcuesFlutterOptions();
     options.logging = true;
-    await AppcuesFlutter.initialize('ACCOUNT_ID', 'APP_ID', options);
+    await AppcuesFlutter.initialize('APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID', options);
     await AppcuesFlutter.identify('flutter-user-00000');
     return true;
   }


### PR DESCRIPTION
Was able to get this working locally now that the app is approved.  The issue was that the flutter gradle scripts put the .aab file up a level from the android app being built, in a build/app/outputs cross platform path.  We can supply the direct path to the upload task.

Also, corrected an issue where the account/app placeholders were not being replaced.