### PR TITLE
Include version update in release notes

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -99,7 +99,7 @@ git commit -am "🔖 Update version to $newVersion"
 git push
 
 # generate the changelog for the git release update
-releaseChangelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬📸✅💡📝🔖]/d')
+releaseChangelog=$(git log --pretty=format:"- [%as] %s (%h)" $(git describe --tags --abbrev=0 @^)..@ --abbrev=7 | sed '/[🔧🎬📸✅💡📝]/d')
 releaseTempFile=$(mktemp)
 echo "$releaseChangelog" >> $releaseTempFile
 


### PR DESCRIPTION
Didn't quite get it correct in https://github.com/appcues/appcues-flutter-plugin/commit/275ce50817b7e62e6fc52a0b92a2d3a32943b6eb (manually fixed 2.0 release), as it was still filtering out 🔖 commits. Fixed