### PR TITLE
Add support for element targeting

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.appcues.flutter"
     compileSdkVersion 33
 
     compileOptions {
@@ -46,5 +47,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.appcues:appcues:2.1.2'
+    implementation 'com.appcues:appcues:2.1.4'
 }

--- a/android/src/main/kotlin/com/appcues/flutter/AppcuesFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/AppcuesFlutterPlugin.kt
@@ -222,11 +222,11 @@ class AppcuesFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     result.badArgs("url")
                 }
             }
-            "targetElement" -> {
-                elementTargeting.targetElement(call)
-            }
-            "resetTargetElements" -> {
-                elementTargeting.resetTargetElements()
+            "setTargetElements" -> {
+                var viewElements = call.argument<List<HashMap<String, Any>>>("viewElements");
+                if (viewElements != null) {
+                    elementTargeting.setTargetElements(viewElements)
+                }
             }
             else -> result.notImplemented()
         }

--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -1,0 +1,158 @@
+package com.appcues.flutter
+
+import android.app.Activity
+import android.graphics.Rect
+import android.os.Build
+import android.util.Size
+import android.view.View
+import android.view.ViewGroup
+import android.view.inspector.WindowInspector
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.appcues.ElementSelector
+import com.appcues.ElementTargetingStrategy
+import com.appcues.Screenshot
+import com.appcues.ViewElement
+import io.flutter.plugin.common.MethodCall
+import java.lang.reflect.Method
+
+internal class FlutterElementSelector(var identifier: String?): ElementSelector {
+    val isValid: Boolean
+        get() = identifier != null
+
+    override fun toMap(): Map<String, String> =
+        mapOf(
+            "identifier" to identifier,
+        ).filterValues { it != null }.mapValues { it.value as String }
+
+    override fun evaluateMatch(target: ElementSelector): Int {
+        var weight = 0
+
+        (target as? FlutterElementSelector)?.let {
+            if (!it.identifier.isNullOrEmpty() && it.identifier == identifier) {
+                weight += 1_000
+            }
+        }
+
+        return weight
+    }
+}
+
+internal fun Activity.getParentView(): ViewGroup {
+
+    // try to find the most applicable topmost decorView to capture layout. Typically there is just a single
+    // decorView on the Activity window. However, if something like a dialog modal has been shown, this can add another
+    // window with another decorView on top of the Activity. If we want to support showing content above that layer, we need
+    // to find the topmost decorView like below.
+
+    val decorView = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        // this is the preferred method on API 29+ with the new WindowInspector function
+        WindowInspector.getGlobalWindowViews().last()
+    } else {
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        try {
+            // this is the less desirable method for API 21-28, using reflection to try to get the root views
+            val windowManagerClass = Class.forName("android.view.WindowManagerGlobal")
+            val windowManager = windowManagerClass.getMethod("getInstance").invoke(null)
+            val getViewRootNames: Method = windowManagerClass.getMethod("getViewRootNames")
+            val getRootView: Method = windowManagerClass.getMethod("getRootView", String::class.java)
+            val rootViewNames = getViewRootNames.invoke(windowManager) as Array<Any?>
+            val rootViews = rootViewNames.map { getRootView(windowManager, it) as View }
+            rootViews.last()
+        } catch (_: Exception) {
+            // if all else fails, use the decorView on the window, which is typically the only one
+            window.decorView
+        }
+    }
+
+    return decorView.rootView as ViewGroup
+}
+
+internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin) : ElementTargetingStrategy {
+
+    private var widgets: MutableMap<String, ViewElement> = mutableMapOf()
+
+    override fun captureLayout(): ViewElement? {
+        return plugin.activity?.getParentView()?.let {
+            val actualPosition = Rect()
+            it.getGlobalVisibleRect(actualPosition)
+
+            val displayMetrics = it.context.resources.displayMetrics
+            val density = displayMetrics.density
+
+            return ViewElement(
+                x = actualPosition.left.toDp(density),
+                y = actualPosition.top.toDp(density),
+                width = actualPosition.width().toDp(density),
+                height = actualPosition.height().toDp(density),
+                selector = null,
+                displayName = null,
+                type = this.javaClass.name,
+                children = widgets.values.toList(),
+            )
+        }
+    }
+
+    override fun inflateSelectorFrom(properties: Map<String, String>): ElementSelector? {
+        return FlutterElementSelector(
+            identifier = properties["identifier"],
+        ).let { if (it.isValid) it else null }
+    }
+
+    override fun captureScreenshot(): Screenshot? {
+        return plugin.activity?.let { activity ->
+            val view = activity.getParentView()
+            val density = view.resources.displayMetrics.density
+
+            // get the root level window insets, which will be used to apply a height correction
+            // to the screenshot below
+            val insets = ViewCompat.getRootWindowInsets(view)?.getInsets(WindowInsetsCompat.Type.systemBars())
+                ?: Insets.NONE
+
+            // This bitmap from the FlutterRenderer contains the top system bar but not the bottom
+            val bitmap = plugin.renderer.bitmap
+
+            // so bottom is subtracted from the screenshot height
+            val width = view.width.toDp(density)
+            val height = (view.height - insets.bottom).toDp(density)
+
+            Screenshot(
+                bitmap = bitmap,
+                size = Size(width, height),
+                // zero out the bottom insets for the screen capture builder usage
+                insets = Insets.of(insets.left, insets.top, insets.right, 0)
+            )
+        }
+
+    }
+
+    fun targetElement(call: MethodCall) {
+        val identifier = call.argument<String>("identifier")
+        val x = call.argument<Double>("x")
+        val y = call.argument<Double>("y")
+        val width = call.argument<Double>("width")
+        val height = call.argument<Double>("height")
+        val type = call.argument<String>("type")
+
+        if (identifier != null && x != null && y != null && width != null && height != null && type != null) {
+            widgets[identifier] = ViewElement(
+                x = x.toInt(),
+                y = y.toInt(),
+                width = width.toInt(),
+                height = height.toInt(),
+                type = type,
+                selector = FlutterElementSelector(identifier),
+                children = null,
+                displayName = identifier
+            )
+        }
+    }
+
+    fun resetTargetElements() {
+        widgets.clear()
+    }
+}
+
+private fun Int.toDp(density: Float) =
+    (this / density).toInt()

--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -71,7 +71,7 @@ internal fun Activity.getParentView(): ViewGroup {
 
 internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin) : ElementTargetingStrategy {
 
-    private var widgets: MutableMap<String, ViewElement> = mutableMapOf()
+    private var targetElements: List<ViewElement> = listOf()
 
     override fun captureLayout(): ViewElement? {
         return plugin.activity?.getParentView()?.let {
@@ -89,7 +89,7 @@ internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin)
                 selector = null,
                 displayName = null,
                 type = this.javaClass.name,
-                children = widgets.values.toList(),
+                children = targetElements,
             )
         }
     }
@@ -127,30 +127,30 @@ internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin)
 
     }
 
-    fun targetElement(call: MethodCall) {
-        val identifier = call.argument<String>("identifier")
-        val x = call.argument<Double>("x")
-        val y = call.argument<Double>("y")
-        val width = call.argument<Double>("width")
-        val height = call.argument<Double>("height")
-        val type = call.argument<String>("type")
+    fun setTargetElements(viewElements: List<HashMap<String, Any>>) {
+        targetElements = viewElements.mapNotNull { element ->
+            val identifier = element["identifier"] as? String
+            val x = element["x"] as? Double
+            val y = element["y"] as? Double
+            val width = element["width"] as? Double
+            val height = element["height"] as? Double
+            val type = element["type"] as? String
 
-        if (identifier != null && x != null && y != null && width != null && height != null && type != null) {
-            widgets[identifier] = ViewElement(
-                x = x.toInt(),
-                y = y.toInt(),
-                width = width.toInt(),
-                height = height.toInt(),
-                type = type,
-                selector = FlutterElementSelector(identifier),
-                children = null,
-                displayName = identifier
-            )
+            if (identifier != null && x != null && y != null && width != null && height != null && type != null) {
+                ViewElement(
+                    x = x.toInt(),
+                    y = y.toInt(),
+                    width = width.toInt(),
+                    height = height.toInt(),
+                    type = type,
+                    selector = FlutterElementSelector(identifier),
+                    children = null,
+                    displayName = identifier
+                )
+            } else {
+                null
+            }
         }
-    }
-
-    fun resetTargetElements() {
-        widgets.clear()
     }
 }
 

--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -23,7 +23,7 @@ internal class FlutterElementSelector(var identifier: String?): ElementSelector 
 
     override fun toMap(): Map<String, String> =
         mapOf(
-            "identifier" to identifier,
+            "appcuesID" to identifier,
         ).filterValues { it != null }.mapValues { it.value as String }
 
     override fun evaluateMatch(target: ElementSelector): Int {
@@ -96,7 +96,7 @@ internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin)
 
     override fun inflateSelectorFrom(properties: Map<String, String>): ElementSelector? {
         return FlutterElementSelector(
-            identifier = properties["identifier"],
+            identifier = properties["appcuesID"],
         ).let { if (it.isValid) it else null }
     }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/example/lib/src/app.dart
+++ b/example/lib/src/app.dart
@@ -102,6 +102,7 @@ class _ExampleState extends State<Example> {
     options.logging = true;
     await Appcues.initialize(
         'APPCUES_ACCOUNT_ID', 'APPCUES_APPLICATION_ID', options);
+    Appcues.enableElementTargeting();
   }
 
   // Detect if app was launched from a deeplink

--- a/example/lib/src/screens/events.dart
+++ b/example/lib/src/screens/events.dart
@@ -27,35 +27,39 @@ class EventsScreen extends StatelessWidget {
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  // Foreground color
-                  onPrimary: Theme.of(context).colorScheme.onPrimary,
-                  // Background color
-                  primary: Theme.of(context).colorScheme.primary,
-                  minimumSize: const Size.fromHeight(44),
-                ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
-                onPressed: () async {
-                  Appcues.track("event1");
-                },
-                child: const Text('Trigger Event 1'),
-              ),
+              child: Semantics(
+                  tagForChildren: const AppcuesView("btnEvent1"),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      // Foreground color
+                      onPrimary: Theme.of(context).colorScheme.onPrimary,
+                      // Background color
+                      primary: Theme.of(context).colorScheme.primary,
+                      minimumSize: const Size.fromHeight(44),
+                    ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+                    onPressed: () async {
+                      Appcues.track("event1");
+                    },
+                    child: const Text('Trigger Event 1'),
+                  )),
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 8, 0, 0),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  // Foreground color
-                  onPrimary: Theme.of(context).colorScheme.onPrimary,
-                  // Background color
-                  primary: Theme.of(context).colorScheme.primary,
-                  minimumSize: const Size.fromHeight(44),
-                ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
-                onPressed: () async {
-                  Appcues.track("event2");
-                },
-                child: const Text('Trigger Event 2'),
-              ),
+              child: Semantics(
+                  tagForChildren: const AppcuesView("btnEvent2"),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      // Foreground color
+                      onPrimary: Theme.of(context).colorScheme.onPrimary,
+                      // Background color
+                      primary: Theme.of(context).colorScheme.primary,
+                      minimumSize: const Size.fromHeight(44),
+                    ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+                    onPressed: () async {
+                      Appcues.track("event2");
+                    },
+                    child: const Text('Trigger Event 2'),
+                  )),
             ),
           ],
         ),

--- a/example/lib/src/screens/group.dart
+++ b/example/lib/src/screens/group.dart
@@ -35,24 +35,26 @@ class _GroupScreenState extends State<GroupScreen> {
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  // Foreground color
-                  onPrimary: Theme.of(context).colorScheme.onPrimary,
-                  // Background color
-                  primary: Theme.of(context).colorScheme.primary,
-                  minimumSize: const Size.fromHeight(44),
-                ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
-                onPressed: () async {
-                  var text = _groupController.value.text;
-                  if (text.isNotEmpty) {
-                    Appcues.group(text);
-                  } else {
-                    Appcues.group(null);
-                  }
-                },
-                child: const Text('Save'),
-              ),
+              child: Semantics(
+                  tagForChildren: const AppcuesView("btnSaveGroup"),
+                  child: ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      // Foreground color
+                      onPrimary: Theme.of(context).colorScheme.onPrimary,
+                      // Background color
+                      primary: Theme.of(context).colorScheme.primary,
+                      minimumSize: const Size.fromHeight(44),
+                    ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+                    onPressed: () async {
+                      var text = _groupController.value.text;
+                      if (text.isNotEmpty) {
+                        Appcues.group(text);
+                      } else {
+                        Appcues.group(null);
+                      }
+                    },
+                    child: const Text('Save'),
+                  )),
             ),
           ],
         ),

--- a/example/lib/src/screens/profile.dart
+++ b/example/lib/src/screens/profile.dart
@@ -58,23 +58,26 @@ class _ProfileScreenState extends State<ProfileScreen> {
             ),
             Padding(
               padding: const EdgeInsets.fromLTRB(0, 16, 0, 0),
-              child: ElevatedButton(
-                style: ElevatedButton.styleFrom(
-                  // Foreground color
-                  onPrimary: Theme.of(context).colorScheme.onPrimary,
-                  // Background color
-                  primary: Theme.of(context).colorScheme.primary,
-                  minimumSize: const Size.fromHeight(44),
-                ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
-                onPressed: () async {
-                  if (!authState.isAnonymous) {
-                    Appcues.identify(authState.username, {
-                      "givenName": _givenNameController.value.text,
-                      "familyName": _familyNameController.value.text,
-                    });
-                  }
-                },
-                child: const Text('Save'),
+              child: Semantics(
+                tagForChildren: const AppcuesView("btnSaveProfile"),
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    // Foreground color
+                    onPrimary: Theme.of(context).colorScheme.onPrimary,
+                    // Background color
+                    primary: Theme.of(context).colorScheme.primary,
+                    minimumSize: const Size.fromHeight(44),
+                  ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
+                  onPressed: () async {
+                    if (!authState.isAnonymous) {
+                      Appcues.identify(authState.username, {
+                        "givenName": _givenNameController.value.text,
+                        "familyName": _familyNameController.value.text,
+                      });
+                    }
+                  },
+                  child: const Text('Save'),
+                ),
               ),
             ),
           ],

--- a/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
+++ b/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
@@ -4,7 +4,7 @@ import AppcuesKit
 
 internal class FlutterElementSelector: AppcuesElementSelector {
     private enum CodingKeys: String, CodingKey {
-        case identifier
+        case appcuesID
     }
 
     let identifier: String
@@ -30,7 +30,7 @@ internal class FlutterElementSelector: AppcuesElementSelector {
     override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if !identifier.isEmpty {
-            try container.encode(identifier, forKey: .identifier)
+            try container.encode(identifier, forKey: .appcuesID)
         }
     }
 }
@@ -57,7 +57,7 @@ internal class FlutterElementTargeting: AppcuesElementTargeting {
     }
 
     func inflateSelector(from properties: [String: String]) -> AppcuesElementSelector? {
-        return FlutterElementSelector(identifier: properties["identifier"])
+        return FlutterElementSelector(identifier: properties["appcuesID"])
     }
 
     func targetElement(properties: Dictionary<String, Any>) {

--- a/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
+++ b/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
@@ -1,0 +1,89 @@
+import Flutter
+import UIKit
+import AppcuesKit
+
+internal class FlutterElementSelector: AppcuesElementSelector {
+    private enum CodingKeys: String, CodingKey {
+        case identifier
+    }
+
+    let identifier: String
+
+    init?(identifier: String?) {
+        // must have at least one identifiable property to be a valid selector
+        guard let identifier = identifier else {
+            return nil
+        }
+
+        self.identifier = identifier
+        super.init()
+    }
+
+    override func evaluateMatch(for target: AppcuesElementSelector) -> Int {
+        guard let target = target as? FlutterElementSelector else {
+            return 0
+        }
+
+        return identifier == target.identifier ? 10_000 : 0
+    }
+
+    override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if !identifier.isEmpty {
+            try container.encode(identifier, forKey: .identifier)
+        }
+    }
+}
+
+@available(iOS 13.0, *)
+internal class FlutterElementTargeting: AppcuesElementTargeting {
+
+    private var widgets: [String: AppcuesViewElement] = [:]
+
+    func captureLayout() -> AppcuesViewElement? {
+        guard let captureWindow = UIApplication.shared.windows.first(where: { !$0.isAppcuesWindow }) else {
+            return nil
+        }
+
+        return AppcuesViewElement(
+            x: captureWindow.bounds.origin.x,
+            y: captureWindow.bounds.origin.y,
+            width: captureWindow.bounds.width,
+            height: captureWindow.bounds.height,
+            type: "\(type(of: captureWindow))",
+            selector: nil,
+            children: Array(widgets.values)
+        )
+    }
+
+    func inflateSelector(from properties: [String: String]) -> AppcuesElementSelector? {
+        return FlutterElementSelector(identifier: properties["identifier"])
+    }
+
+    func targetElement(properties: Dictionary<String, Any>) {
+
+        guard let identifier = properties["identifier"] as? String,
+            let x = properties["x"] as? Double,
+            let y = properties["y"] as? Double,
+            let width = properties["width"] as? Double,
+            let height = properties["height"] as? Double,
+            let type = properties["type"] as? String else {
+            return
+        }
+
+        widgets[identifier] = AppcuesViewElement(
+            x: CGFloat(x),
+            y: CGFloat(y),
+            width: CGFloat(width),
+            height: CGFloat(height),
+            type: type,
+            selector: FlutterElementSelector(identifier: identifier),
+            children: nil,
+            displayName: identifier
+        )
+    }
+
+    func resetTargetElements() {
+        widgets.removeAll()
+    }
+}

--- a/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
+++ b/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
@@ -38,7 +38,7 @@ internal class FlutterElementSelector: AppcuesElementSelector {
 @available(iOS 13.0, *)
 internal class FlutterElementTargeting: AppcuesElementTargeting {
 
-    private var widgets: [String: AppcuesViewElement] = [:]
+    private var targetElements: [AppcuesViewElement] = []
 
     func captureLayout() -> AppcuesViewElement? {
         guard let captureWindow = UIApplication.shared.windows.first(where: { !$0.isAppcuesWindow }) else {
@@ -52,7 +52,7 @@ internal class FlutterElementTargeting: AppcuesElementTargeting {
             height: captureWindow.bounds.height,
             type: "\(type(of: captureWindow))",
             selector: nil,
-            children: Array(widgets.values)
+            children: targetElements
         )
     }
 
@@ -60,30 +60,28 @@ internal class FlutterElementTargeting: AppcuesElementTargeting {
         return FlutterElementSelector(identifier: properties["appcuesID"])
     }
 
-    func targetElement(properties: Dictionary<String, Any>) {
+    func setTargetElements(viewElements: [Dictionary<String, Any>]) {
+        targetElements = viewElements.compactMap { element -> AppcuesViewElement? in
 
-        guard let identifier = properties["identifier"] as? String,
-            let x = properties["x"] as? Double,
-            let y = properties["y"] as? Double,
-            let width = properties["width"] as? Double,
-            let height = properties["height"] as? Double,
-            let type = properties["type"] as? String else {
-            return
+            guard let identifier = element["identifier"] as? String,
+                let x = element["x"] as? Double,
+                let y = element["y"] as? Double,
+                let width = element["width"] as? Double,
+                let height = element["height"] as? Double,
+                let type = element["type"] as? String else {
+                return nil
+            }
+
+            return AppcuesViewElement(
+                x: CGFloat(x),
+                y: CGFloat(y),
+                width: CGFloat(width),
+                height: CGFloat(height),
+                type: type,
+                selector: FlutterElementSelector(identifier: identifier),
+                children: nil,
+                displayName: identifier
+            )
         }
-
-        widgets[identifier] = AppcuesViewElement(
-            x: CGFloat(x),
-            y: CGFloat(y),
-            width: CGFloat(width),
-            height: CGFloat(height),
-            type: type,
-            selector: FlutterElementSelector(identifier: identifier),
-            children: nil,
-            displayName: identifier
-        )
-    }
-
-    func resetTargetElements() {
-        widgets.removeAll()
     }
 }

--- a/ios/Classes/SwiftAppcuesFlutterPlugin.swift
+++ b/ios/Classes/SwiftAppcuesFlutterPlugin.swift
@@ -13,6 +13,10 @@ public class SwiftAppcuesFlutterPlugin: NSObject, FlutterPlugin {
         let instance = SwiftAppcuesFlutterPlugin()
         instance.analyticsChannel = FlutterEventChannel(name: "appcues_analytics", binaryMessenger: registrar.messenger())
         registrar.addMethodCallDelegate(instance, channel: methodChannel)
+
+        if #available(iOS 13.0, *) {
+            Appcues.elementTargeting = FlutterElementTargeting()
+        }
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -129,6 +133,19 @@ public class SwiftAppcuesFlutterPlugin: NSObject, FlutterPlugin {
             } else {
                 result(missingArgs(names: "url"))
             }
+        case "targetElement":
+            guard #available(iOS 13.0, *),
+                  let flutterElementTargeting = Appcues.elementTargeting as? FlutterElementTargeting,
+                  let properties = call.parameters else {
+                return
+            }
+            flutterElementTargeting.targetElement(properties: properties)
+        case "resetTargetElements":
+            guard #available(iOS 13.0, *),
+                  let flutterElementTargeting = Appcues.elementTargeting as? FlutterElementTargeting else {
+                return
+            }
+            flutterElementTargeting.resetTargetElements();
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/ios/Classes/SwiftAppcuesFlutterPlugin.swift
+++ b/ios/Classes/SwiftAppcuesFlutterPlugin.swift
@@ -133,19 +133,14 @@ public class SwiftAppcuesFlutterPlugin: NSObject, FlutterPlugin {
             } else {
                 result(missingArgs(names: "url"))
             }
-        case "targetElement":
+
+        case "setTargetElements":
             guard #available(iOS 13.0, *),
                   let flutterElementTargeting = Appcues.elementTargeting as? FlutterElementTargeting,
-                  let properties = call.parameters else {
+                  let viewElements = call.parameters?["viewElements"] as? Array<Dictionary<String, Any>> else {
                 return
             }
-            flutterElementTargeting.targetElement(properties: properties)
-        case "resetTargetElements":
-            guard #available(iOS 13.0, *),
-                  let flutterElementTargeting = Appcues.elementTargeting as? FlutterElementTargeting else {
-                return
-            }
-            flutterElementTargeting.resetTargetElements();
+            flutterElementTargeting.setTargetElements(viewElements: viewElements)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/material.dart';
 
 /// A set of options that can be configured when initializing the Appcues
 /// plugin.
@@ -85,6 +84,9 @@ class AppcuesView extends SemanticsTag {
 
 /// The main entry point of the Appcues plugin.
 class Appcues {
+
+  static SemanticsHandle? _semanticsHandle;
+
   static const MethodChannel _methodChannel = MethodChannel('appcues_flutter');
   static const EventChannel _analyticsChannel =
       EventChannel('appcues_analytics');
@@ -114,10 +116,17 @@ class Appcues {
         '_dartVersion': Platform.version
       }
     });
+  }
 
-    // consider whether this should be opt-in or configurable
-    RendererBinding.instance.pipelineOwner
-        .ensureSemantics(listener: _semanticsChanged);
+  static void enableElementTargeting() {
+    _semanticsHandle ??= RendererBinding.instance.pipelineOwner
+          .ensureSemantics(listener: _semanticsChanged);
+  }
+
+  static void disableElementTargeting() {
+    _semanticsHandle?.dispose();
+    _semanticsHandle = null;
+    _methodChannel.invokeMethod('setTargetElements', {'viewElements': []});
   }
 
   static Stream<AppcuesAnalytic> get onAnalyticEvent {

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -224,18 +224,15 @@ class Appcues {
   // runs every time the SemanticsNode tree updates, capturing the known
   // layout information that can be used for Appcues element targeting
   static void _semanticsChanged() {
-    // clear out any previously captured elements in the view
-    _methodChannel.invokeMethod('resetTargetElements');
-
     var rootSemanticNode = RendererBinding
         .instance.pipelineOwner.semanticsOwner?.rootSemanticsNode;
 
-    if (rootSemanticNode != null) {
+    List<Map<String, dynamic>> viewElements = [];
 
+    if (rootSemanticNode != null) {
       // this function runs on each node in the tree, looking for
       // identifiable elements.
       bool visitor(SemanticsNode node) {
-
         // by default, we use the generated label, if non-empty
         var identifier = node.label;
         var tags = node.tags;
@@ -251,7 +248,6 @@ class Appcues {
         }
 
         if (identifier.isNotEmpty) {
-
           // the SemanticsNode rect is in local coordinates. This helper
           // will recursively walk the ancestors and transform the rect
           // into global coordinates for the screen.
@@ -273,9 +269,8 @@ class Appcues {
           // do the transform to global coordinates
           var rect = transformToRoot(node.rect, node);
 
-          // pass this target element through to the native side to capture
-          // in the current known set of views for targeting
-          _methodChannel.invokeMethod('targetElement', {
+          // add this item to the set of captured views
+          viewElements.add({
             'x': rect.left,
             'y': rect.top,
             'width': rect.width,
@@ -292,6 +287,10 @@ class Appcues {
 
       // start the tree inspection
       rootSemanticNode.visitChildren(visitor);
+
+      // pass the target elements found to the native side to capture
+      // the current known set of views for element targeting
+      _methodChannel.invokeMethod('setTargetElements', {'viewElements': viewElements});
     }
   }
 }


### PR DESCRIPTION
for [sc-53359]

This is a functional POC for Flutter element targeting, but definitely still early phase and open to a lot of feedback and consideration around how we are monitoring the [Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html) tree.

The general idea here is that the Appcues SDK registers a [SemanticsNode](https://api.flutter.dev/flutter/semantics/SemanticsNode-class.html) change listener at SDK startup, and then monitors and pushes view layout information to the native sides (via MethodChannel) when changes are detected. The SemanticsNode [visitChildren](https://api.flutter.dev/flutter/semantics/SemanticsNode/visitChildren.html) function provides the means to gather this info. We can capture a custom view identifier through a SemanticsTag, or just use a system generated label as a fallback.

The native side maintains a set of currently known targetable views, and uses that for screen capture and target-element lookup operations.

This allows for the typical behaviors around targeting elements for tooltips:

https://github.com/appcues/appcues-flutter-plugin/assets/19266448/aefc1c66-6470-4dfd-8f4a-7cb62b102317

As well as screen capture:
![Screenshot 2023-07-11 at 3 57 32 PM](https://github.com/appcues/appcues-flutter-plugin/assets/19266448/1a8b978c-f8de-4303-a4a0-84e52d537fcc)

Android screen capture took some extra work, thus these changes are built on new Android SDK functionality to allow plugins to control the screen image capture in https://github.com/appcues/appcues-android-sdk/pull/429. Flutter Android does not support our general capture functionality from the root view of the Activity, and thus specialized logic is added here to pull the image Bitmap from the FlutterRenderer (will note this spot inline).

