### PR TITLE
Remove usage of uni_links in example app

### DIFF
--- a/example/android/app/src/main/kotlin/com/appcues/samples/flutter/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/com/appcues/samples/flutter/MainActivity.kt
@@ -1,6 +1,67 @@
 package com.appcues.samples.flutter
 
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterFragmentActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugins.GeneratedPluginRegistrant
 
 class MainActivity: FlutterFragmentActivity() {
+    companion object {
+        const val CHANNEL = "com.appcues.samples.flutter/channel"
+        const val EVENTS = "com.appcues.samples.flutter/events"
+    }
+
+    private var startString: String? = null
+    private var linksReceiver: BroadcastReceiver? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        GeneratedPluginRegistrant.registerWith(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor, CHANNEL).setMethodCallHandler { call, result ->
+            if (call.method == "initialLink") {
+                if (startString != null) {
+                    result.success(startString)
+                }
+            }
+        }
+
+        EventChannel(flutterEngine.dartExecutor, EVENTS).setStreamHandler(
+            object : EventChannel.StreamHandler {
+                override fun onListen(args: Any?, events: EventChannel.EventSink) {
+                    linksReceiver = createChangeReceiver(events)
+                }
+
+                override fun onCancel(args: Any?) {
+                    linksReceiver = null
+                }
+            }
+        )
+    }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startString = intent.data?.toString()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (intent.action === Intent.ACTION_VIEW) {
+            linksReceiver?.onReceive(this.applicationContext, intent)
+        }
+    }
+
+    fun createChangeReceiver(events: EventChannel.EventSink): BroadcastReceiver? {
+        return object : BroadcastReceiver() {
+            // NOTE: assuming intent.getAction() is Intent.ACTION_VIEW
+            override fun onReceive(context: Context, intent: Intent) {
+                val dataString = intent.dataString ?:
+                events.error("UNAVAILABLE", "Link unavailable", null)
+                events.success(dataString)
+            }
+        }
+    }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,16 +1,13 @@
 PODS:
   - Appcues (2.1.1)
-  - appcues_flutter (2.1.0):
+  - appcues_flutter (2.1.1):
     - Appcues (~> 2.1.1)
     - Flutter
   - Flutter (1.0.0)
-  - uni_links (0.0.1):
-    - Flutter
 
 DEPENDENCIES:
   - appcues_flutter (from `.symlinks/plugins/appcues_flutter/ios`)
   - Flutter (from `Flutter`)
-  - uni_links (from `.symlinks/plugins/uni_links/ios`)
 
 SPEC REPOS:
   trunk:
@@ -21,14 +18,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/appcues_flutter/ios"
   Flutter:
     :path: Flutter
-  uni_links:
-    :path: ".symlinks/plugins/uni_links/ios"
 
 SPEC CHECKSUMS:
   Appcues: 6293ef6ca66be2e37f9b02248d87de5cbd569a98
-  appcues_flutter: 569d1096aa949dc97caee5b41ae62470201654e3
+  appcues_flutter: 4103f7bbe7bd634a1e57faec04951c3df98e5282
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
 
 PODFILE CHECKSUM: 69a94f836326f2bab375ad9c9e93cae9179c7221
 

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -3,11 +3,67 @@ import Flutter
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+
+    private var methodChannel: FlutterMethodChannel?
+    private var eventChannel: FlutterEventChannel?
+    private let linkStreamHandler = LinkStreamHandler()
+
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+
+        let initialLink = launchOptions?[.url] as? String
+
+        let controller = window.rootViewController as! FlutterViewController
+        methodChannel = FlutterMethodChannel(name: "com.appcues.samples.flutter/channel", binaryMessenger: controller as! FlutterBinaryMessenger)
+        eventChannel = FlutterEventChannel(name: "com.appcues.samples.flutter/events", binaryMessenger: controller as! FlutterBinaryMessenger)
+
+        methodChannel?.setMethodCallHandler({ (call: FlutterMethodCall, result: FlutterResult) in
+            guard call.method == "initialLink" else {
+                result(FlutterMethodNotImplemented)
+                return
+            }
+
+            result(initialLink)
+        })
+
+        GeneratedPluginRegistrant.register(with: self)
+        eventChannel?.setStreamHandler(linkStreamHandler)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        eventChannel?.setStreamHandler(linkStreamHandler)
+        return linkStreamHandler.handleLink(url.absoluteString)
+    }
+}
+
+class LinkStreamHandler:NSObject, FlutterStreamHandler {
+
+    var eventSink: FlutterEventSink?
+
+    // links will be added to this queue until the sink is ready to process them
+    var queuedLinks = [String]()
+
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        self.eventSink = events
+        queuedLinks.forEach({ events($0) })
+        queuedLinks.removeAll()
+        return nil
+    }
+
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        self.eventSink = nil
+        return nil
+    }
+
+    func handleLink(_ link: String) -> Bool {
+        guard let eventSink = eventSink else {
+            queuedLinks.append(link)
+            return false
+        }
+        eventSink(link)
+        return true
+    }
 }

--- a/example/lib/src/app.dart
+++ b/example/lib/src/app.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:appcues_flutter/appcues_flutter.dart';
 import 'package:flutter/material.dart';
-import 'package:uni_links/uni_links.dart';
+import 'package:flutter/services.dart';
 
 import 'auth.dart';
 import 'routing.dart';
@@ -23,10 +23,15 @@ class _ExampleState extends State<Example> {
   late final SimpleRouterDelegate _routerDelegate;
   late final TemplateRouteParser _routeParser;
 
-  bool _initialURILinkHandled = false;
+  // Event Channel creation
+  // used for listening for deep links from platform code
+  static const stream = EventChannel('com.appcues.samples.flutter/events');
 
-  // handle for listening for incoming deeplinks
-  StreamSubscription? _linkStreamSubscription;
+  // Method channel creation
+  // used to check for initial deep link when launching app, from platform
+  static const platform = MethodChannel('com.appcues.samples.flutter/channel');
+
+  bool _initialURILinkHandled = false;
 
   @override
   void initState() {
@@ -55,8 +60,10 @@ class _ExampleState extends State<Example> {
     // Initialize the Appcues Plugin
     _initializeAppcues();
 
-    _handleInitialDeeplink();
-    _listenForDeeplinks();
+    //Checking application start by deep link
+    _startUri().then(_onRedirected);
+    //Checking broadcast stream, if deep link was clicked in opened application
+    stream.receiveBroadcastStream().listen((d) => _onRedirected(d));
 
     // Listen for when the user logs out and display the signin screen.
     _auth.addListener(_handleAuthStateChanged);
@@ -98,38 +105,27 @@ class _ExampleState extends State<Example> {
   }
 
   // Detect if app was launched from a deeplink
-  Future<void> _handleInitialDeeplink() async {
+  Future<String?> _startUri() async {
     // guard against processing initial link more than once
     if (!_initialURILinkHandled) {
       _initialURILinkHandled = true;
-
-      final initialURI = await getInitialUri();
-      if (mounted && initialURI != null) {
-        // Pass along to Appcues to potentially handle
-        bool handled = await Appcues.didHandleURL(initialURI);
-        if (handled) return;
-
-        // Otherwise, process the link as a normal app route
-        var route = await _routeParser
-            .parseRouteInformation(RouteInformation(location: initialURI.path));
-        _routeState.route = route;
-      }
+      return platform.invokeMethod('initialLink');
     }
+    return null;
   }
 
-  // Detect if a new deeplink was sent to the app
-  void _listenForDeeplinks() {
-    _linkStreamSubscription = uriLinkStream.listen((Uri? uri) async {
-      if (!mounted || uri == null) return;
-      // Pass along to Appcues to potentially handle
-      bool handled = await Appcues.didHandleURL(uri);
-      if (handled) return;
+  // Handle any deep link sent to the app
+  Future<void> _onRedirected(String? url) async {
+    if (!mounted || url == null) return;
+    var uri = Uri.parse(url);
+    // Pass along to Appcues to potentially handle
+    bool handled = await Appcues.didHandleURL(uri);
+    if (handled) return;
 
-      // Otherwise, process the link as a normal app route
-      var route = await _routeParser
-          .parseRouteInformation(RouteInformation(location: uri.path));
-      _routeState.route = route;
-    });
+    // Otherwise, process the link as a normal app route
+    var route = await _routeParser
+        .parseRouteInformation(RouteInformation(location: uri.path));
+    _routeState.route = route;
   }
 
   void _handleAuthStateChanged() {
@@ -152,7 +148,6 @@ class _ExampleState extends State<Example> {
     _routerDelegate.removeListener(_handleRouteStateChanged);
     _routeState.dispose();
     _routerDelegate.dispose();
-    _linkStreamSubscription?.cancel();
     super.dispose();
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,15 +23,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "2.1.1"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -44,10 +44,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -98,19 +98,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -123,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
@@ -139,26 +134,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
-  plugin_platform_interface:
-    dependency: transitive
-    description:
-      name: plugin_platform_interface
-      sha256: "075f927ebbab4262ace8d0b283929ac5410c0ac4e7fc123c76429564facfb757"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,34 +195,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.16"
-  uni_links:
-    dependency: "direct main"
-    description:
-      name: uni_links
-      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
-  uni_links_platform_interface:
-    dependency: transitive
-    description:
-      name: uni_links_platform_interface
-      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
-  uni_links_web:
-    dependency: transitive
-    description:
-      name: uni_links_web
-      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.0"
   vector_math:
     dependency: transitive
     description:
@@ -245,5 +208,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.0.0-0 <4.0.0"
   flutter: ">=2.5.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,7 +16,6 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
-  uni_links: ^0.5.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
As mentioned originally in https://github.com/appcues/appcues-flutter-plugin/pull/44, we can fairly easily decouple from any library usage for deep linking in the example, so we have full flexibility with future updates. `uni_links` in particular has not been updated for a long time and causes issues if attempting to use newer Gradle versions in the future.

[This article](https://medium.com/flutter-community/deep-links-and-flutter-applications-how-to-handle-them-properly-8c9865af9283) and the [related example code](https://github.com/DenisovAV/deep_links_flutter) were really helpful in doing so. Another reference is the [source of uni_links](https://github.com/avioli/uni_links) itself. Basically, just need a little but of platform code to handle a method channel and event channel to pass link information back to the Flutter side and allow for the checking of Appcues deep links that we require.

Updated related doc as well to remove `uni_links` reference and update the code snippet.