### PR TITLE
Add anchored tooltip doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This Plugin package is a bridge between the native Appcues SDKs in a Flutter app
       - [Supporting Debugging and Experience Previewing](#supporting-debugging-and-experience-previewing)
     - [Identifying Users](#identifying-users)
     - [Tracking Screens and Events](#tracking-screens-and-events)
+    - [Anchored Tooltips](#anchored-tooltips)
   - [🛠 Customization](#-customization)
   - [📝 Documentation](#-documentation)
   - [🎬 Examples](#-examples)
@@ -105,6 +106,10 @@ Appcues.screen('Contact List');
 // Track screen with property
 Appcues.screen('Contact Details', {'Contact Reference': 'abc'});
 ```
+
+### Anchored Tooltips
+
+Anchored tooltips use element targeting to point directly at specific views in your application. For more information about how to configure your application's views for element targeting, refer to the [Anchored Tooltips Guide](https://github.com/appcues/appcues-flutter-plugin/blob/main/doc/AnchoredTooltips.md).
 
 ## 📝 Documentation
 

--- a/doc/AnalyticObserving.md
+++ b/doc/AnalyticObserving.md
@@ -30,7 +30,7 @@ There are four different possible values for `analytic` and two possible values 
 | `EVENT`        | `true`       | N/A                   |
 | `EVENT`        | `false`      | `Appcues.track()`     |
 | `SCREEN`       | `false`      | `Appcues.screen()`    |
-| `IDENTIFY`     | `false`      | `Appcues.identify()` |
+| `IDENTIFY`     | `false`      | `Appcues.identify()`  |
 | `GROUP`        | `false`      | `Appcues.group()`     |
 
 Events with `isInternal == true` correspond to internal SDK events - these capture anything that is generated automatically inside of the Appcues SDK, including flow events and session events.

--- a/doc/AnalyticObserving.md
+++ b/doc/AnalyticObserving.md
@@ -30,7 +30,7 @@ There are four different possible values for `analytic` and two possible values 
 | `EVENT`        | `true`       | N/A                   |
 | `EVENT`        | `false`      | `Appcues.track()`     |
 | `SCREEN`       | `false`      | `Appcues.screen()`    |
-| `IDENTIFY`     | `false`      | `Appcues.identitfy()` |
+| `IDENTIFY`     | `false`      | `Appcues.identify()` |
 | `GROUP`        | `false`      | `Appcues.group()`     |
 
 Events with `isInternal == true` correspond to internal SDK events - these capture anything that is generated automatically inside of the Appcues SDK, including flow events and session events.

--- a/doc/AnchoredTooltips.md
+++ b/doc/AnchoredTooltips.md
@@ -1,0 +1,58 @@
+# Configuring Views for Anchored Tooltips
+
+The Appcues Flutter plugin supports anchored tooltips targeting widgets in your application's layout.
+
+Tooltips in Flutter utilize the [Semantics](https://api.flutter.dev/flutter/widgets/Semantics-class.html) tree that a Flutter application creates to describe each screen's layout. Layout information is provided automatically that can be used to target many views in your application. Additionally, you can instrument your layout with Semantics widgets to provide custom tag information, and have full control over how your target elements are identified.
+
+The Semantics information allows the Appcues Flutter plugin to create a mobile view selector for each view. This selector is used by the Appcues Mobile Builder to create and target anchored tooltips. When a user qualifies for a flow, this selector is used to render the anchored tooltip content.
+
+## Enabling Element Targeting
+
+Appcues anchored tooltip support in Flutter uses a listener for Semantics tree updates, using the PipelineOwner [ensureSemantics](https://api.flutter.dev/flutter/rendering/PipelineOwner/ensureSemantics.html) method. Usage of this feature is optional. To enable anchored tooltip support call:
+```dart
+Appcues.enableElementTargeting();
+```
+
+If it is necessary to disable this feature in any section of an application, call:
+```dart
+Appcues.disableElementTargeting();
+```
+
+To support capturing screens for usage in the mobile builder to target anchored tooltips, the element targeting feature must be enabled.
+
+## Instrumenting Layouts with Additional Semantics
+
+As noted above, the default Semantics information about your application's layout will be available automatically. To have full control over how a view is identified, use the `AppcuesView` SemanticsTag, and provide a specific identifier String value.
+
+For example, an application layout contains an ElevatedButton:
+```dart
+ElevatedButton(
+    style: ... ,
+    onPressed: () { ... },
+    child: const Text('Save Profile'),
+)
+```
+
+Wrap this widget with Semantics, and provide a `tagForChildren` value that contains an instance of an `AppcuesView` tag, with the specific identifier for targeting.
+```dart
+Semantics(
+    tagForChildren: const AppcuesView("btnSaveProfile"),
+    child: ElevatedButton(
+        style: ... ,
+        onPressed: () { ... },
+        child: const Text('Save Profile'),
+    )
+)     
+```
+
+The identifier `btnSaveProfile` will now be available to target anchored tooltips in the mobile builder. The value is also used to locate the view to anchor the tooltip at runtime in your Flutter application. 
+
+The best way to ensure great performance of Flutter anchored tooltips in Appcues is to set a unique `AppcuesView` tag in Semantics, on each element that may be targeted. The `AppcuesView` identifier value must be unique on the screen where an anchored tooltip may be targeted.
+
+## Other Considerations
+
+### Selector Uniqueness
+Ensure that view identifiers used for selectors are unique within the visible views on the screen at the time an anchored tooltip is attempting to render. If no unique match is found, the Appcues flow will terminate with an error. It is not required that selectors are globally unique across the application, but they must be on any given screen layout.
+
+### Consistent View Identifiers
+Maintain consistency with view identifiers as new versions of the app are released. For example, if a key navigation tab was using an identifier like "Home Tab" in several versions of the application, then changed to "Home" - this would break the ability for selectors using "Home Tab" to be able to find that view and target a tooltip in the newer versions of the app. You could build multiple flows targeting different versions of the application, but it helps keep things simplest if consistent view identifiers can be maintained over time.


### PR DESCRIPTION
Provides info about how to enable element targeting and add Semantics information for more refined selectors.

Also link from main README and fix a typo in another doc.