### PR TITLE
Update suggested items from latest package publish

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.2"
   async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the appcues_flutter plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 2.1.2
 environment:
-  sdk: ">=2.17.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <4.0.0"
 dependencies:
   adaptive_navigation: ^0.0.3
   appcues_flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.1.2
 homepage: https://www.appcues.com
 repository: https://github.com/appcues/appcues-flutter-plugin
 environment:
-  sdk: ">=2.16.2 <3.0.0"
+  sdk: ">=2.16.2 <4.0.0"
   flutter: ">=2.5.0"
 dependencies:
   flutter:

--- a/test/appcues_test.dart
+++ b/test/appcues_test.dart
@@ -8,13 +8,15 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       return '42';
     });
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('getPlatformVersion', () async {


### PR DESCRIPTION
These items appear to have no impact on functionality or the most recent publish or pub score.

However, when the latest release was pushed to pub.dev, a couple of suggestions came up in the console:
```
Package validation found the following potential issue:
* `dart analyze` found the following issue(s):
  Analyzing lib, test, pubspec.yaml...
  
     info - test/appcues_test.dart:11:13 - 'setMockMethodCallHandler' is deprecated and shouldn't be used. Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. Pass the channel as the first argument. This feature was deprecated after v3.9.0-19.0.pre. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
     info - test/appcues_test.dart:17:13 - 'setMockMethodCallHandler' is deprecated and shouldn't be used. Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. Pass the channel as the first argument. This feature was deprecated after v3.9.0-19.0.pre. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
  
  2 issues found.
Package validation found the following hint:
* The declared SDK constraint is '>=2.16.2 <3.0.0', this is interpreted as '>=2.16.2 <4.0.0'.
  
  Consider updating the SDK constraint to:
  
  environment:
    sdk: '>=2.16.2 <4.0.0'
```

So, updating those simple suggested changes here, for future publish.