### PR TITLE
Ensure no empty strings are present in selector property values

### DIFF
--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -19,12 +19,12 @@ import java.lang.reflect.Method
 
 internal class FlutterElementSelector(var identifier: String?): ElementSelector {
     val isValid: Boolean
-        get() = identifier != null
+        get() = identifier.isNullOrEmpty().not()
 
     override fun toMap(): Map<String, String> =
         mapOf(
             "appcuesID" to identifier,
-        ).filterValues { it != null }.mapValues { it.value as String }
+        ).filterValues { it.isNullOrEmpty().not() }.mapValues { it.value as String }
 
     override fun evaluateMatch(target: ElementSelector): Int {
         var weight = 0

--- a/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
+++ b/ios/Classes/ElementTargeting/FlutterElementTargeting.swift
@@ -11,7 +11,7 @@ internal class FlutterElementSelector: AppcuesElementSelector {
 
     init?(identifier: String?) {
         // must have at least one identifiable property to be a valid selector
-        guard let identifier = identifier else {
+        guard let identifier = identifier, !identifier.isEmpty else {
             return nil
         }
 


### PR DESCRIPTION
Some customer data showed selectors with `""` values - we should ignore these and not create selectors that will not provide any unique value. 

Matching what was done in
* iOS https://github.com/appcues/appcues-ios-sdk/pull/431 
* Android https://github.com/appcues/appcues-android-sdk/pull/443
* React Native https://github.com/appcues/appcues-react-native-module/pull/99