### PR TITLE
Update Android SDK and related example app build settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ This Plugin package is a bridge between the native Appcues SDKs in a Flutter app
 ### Prerequisites
 
 #### Android
-Your application's `build.gradle` must have a `compileSdkVersion` of 33+ and `minSdkVersion` of 21+
+Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+
 ```
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 21

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.appcues:appcues:3.1.0'
+    implementation 'com.appcues:appcues:3.1.2'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -15,6 +15,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Appcues (3.1.0)
-  - appcues_flutter (3.0.0):
+  - appcues_flutter (3.1.0):
     - Appcues (~> 3.1.0)
     - Flutter
   - Flutter (1.0.0)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: d0a3f4ec32a1d1ff78ee3a593de732d2e58b68e8
-  appcues_flutter: 22fe59408f429b46076cb6d7a3828e19ee6cdca8
+  appcues_flutter: a5af547a345bef80ba64485eddf04bd134f00bc1
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 
 PODFILE CHECKSUM: 69a94f836326f2bab375ad9c9e93cae9179c7221

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.2"
+    version: "3.1.0"
   async:
     dependency: transitive
     description:


### PR DESCRIPTION
These are the updates to the Flutter plugin project that would be needed to coincide with the core Android SDK changes in https://github.com/appcues/appcues-android-sdk/pull/477

specifically: compiling against SDK 34 (was 33) and updating the Kotlin version.