### PR TITLE
Update element targeting to use new rootPipelineOwner approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
     working_directory: ~/project
   android_compatible:
     machine: 
-      image: android:2022.04.1
+      image: android:2023.07.1
     resource_class: large
     working_directory: ~/project
 
@@ -43,8 +43,8 @@ commands:
     description: 'Install flutter dependencies'    
     steps:            
       - flutter/install_sdk_and_pub:
-          version: 3.7.11
-          cache-version: v3
+          version: 3.16.1
+          cache-version: v4
   setup_gems:
     description: 'Install gem dependencies'
     parameters:

--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -81,11 +81,19 @@ internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin)
             val displayMetrics = it.context.resources.displayMetrics
             val density = displayMetrics.density
 
+            // get the root level window insets, which will be used to apply a height correction below
+            val insets = ViewCompat.getRootWindowInsets(it)?.getInsets(WindowInsetsCompat.Type.systemBars())
+                ?: Insets.NONE
+
+            // the capture from the FlutterRenderer contains the top system bar but not the bottom
+            // so bottom is subtracted from the layout height
+            val height = (actualPosition.height() - insets.bottom).toDp(density)
+
             return ViewElement(
                 x = actualPosition.left.toDp(density),
                 y = actualPosition.top.toDp(density),
                 width = actualPosition.width().toDp(density),
-                height = actualPosition.height().toDp(density),
+                height = height,
                 selector = null,
                 displayName = null,
                 type = this.javaClass.name,

--- a/example/lib/src/screens/events.dart
+++ b/example/lib/src/screens/events.dart
@@ -15,7 +15,7 @@ class EventsScreen extends StatelessWidget {
             onPressed: () {
               Appcues.debug();
             },
-            child: const Text('Debug', style: TextStyle(color: Colors.white)),
+            child: Text('Debug', style: TextStyle(color: Theme.of(context).colorScheme.primary)),
           ),
         ],
       ),
@@ -31,10 +31,8 @@ class EventsScreen extends StatelessWidget {
                   tagForChildren: const AppcuesView("btnEvent1"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {
@@ -49,10 +47,8 @@ class EventsScreen extends StatelessWidget {
                   tagForChildren: const AppcuesView("btnEvent2"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {

--- a/example/lib/src/screens/group.dart
+++ b/example/lib/src/screens/group.dart
@@ -39,10 +39,8 @@ class _GroupScreenState extends State<GroupScreen> {
                   tagForChildren: const AppcuesView("btnSaveGroup"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {

--- a/example/lib/src/screens/profile.dart
+++ b/example/lib/src/screens/profile.dart
@@ -62,10 +62,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 tagForChildren: const AppcuesView("btnSaveProfile"),
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    // Foreground color
-                    onPrimary: Theme.of(context).colorScheme.onPrimary,
-                    // Background color
-                    primary: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
                     minimumSize: const Size.fromHeight(44),
                   ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                   onPressed: () async {

--- a/example/lib/src/screens/sign_in.dart
+++ b/example/lib/src/screens/sign_in.dart
@@ -51,10 +51,8 @@ class _SignInScreenState extends State<SignInScreen> {
                 padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    // Foreground color
-                    onPrimary: Theme.of(context).colorScheme.onPrimary,
-                    // Background color
-                    primary: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
                     minimumSize: const Size.fromHeight(44),
                   ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                   onPressed: () async {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -209,4 +209,4 @@ packages:
     version: "0.3.0"
 sdks:
   dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.13.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.2"
+    version: "3.1.3"
   async:
     dependency: transitive
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -98,14 +98,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -118,26 +110,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   path:
     dependency: transitive
     description:
@@ -155,26 +147,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -195,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
@@ -207,6 +199,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=2.5.0"

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -373,7 +373,7 @@ class Appcues {
               transformed = rect.shift(offset);
             }
 
-            return transformToRoot(transformed, node?.parent);
+            return transformToRoot(transformed, parent);
           }
 
           // do the transform to global coordinates

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://www.appcues.com
 repository: https://github.com/appcues/appcues-flutter-plugin
 environment:
   sdk: ">=2.16.2 <4.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.13.0"
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
Flutter has been making some changes in how the `RendererBinding` works, related to a recent effort around [multi-view support for desktop](https://flutter.dev/go/multiple-views). This led to a recent pub score deduction due to our deprecated usage of the older version.

![Screenshot 2023-11-30 at 10 46 02 AM](https://github.com/appcues/appcues-flutter-plugin/assets/19266448/bd55c013-9552-46d2-b81c-3e1903f8a47f)

I believe a lot of the related code changes are contained in this Flutter change https://github.com/flutter/flutter/commit/6f09064e785b2bb600a390fe6d8be4ac6775b82b

When updating the Flutter version, I discovered that our element targeting approach was no longer working at all - it was not finding or capturing the semantics updates that are required. The change here updates our code to use the new `rootPipelineOwner`, specifically by walking its children `PipelineOwner` objects, recursively. I believe on mobile there will always just be the one view, and thus one child - but this is not totally clear to me yet (multi-view on mobile?). So now, we listen for updates from all of them (in practice just the root that does not update, and the one child that does).

Also, it was discovered that the new selector preview overlay on the capture dialog was not quite showing the selector box in the right spot. This is because of the incorrect height being reported in the layout root view in our capture - it needed to apply the same bottom system inset adjustment that the image capture is using - fixed this.

The new version of Flutter also changes the default theme look and feel, so the example app looks different, but I just continued to stick with the defaults here.

The end result:
![Screenshot 2023-11-30 at 10 14 38 AM](https://github.com/appcues/appcues-flutter-plugin/assets/19266448/1c7bf790-ea44-4dcd-aacf-456f88c60718)

