### PR TITLE
Fix screen capture preview and provide docs for Flutter 3.16+ element targeting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
     working_directory: ~/project
   android_compatible:
     machine: 
-      image: android:2022.04.1
+      image: android:2023.07.1
     resource_class: large
     working_directory: ~/project
 
@@ -43,8 +43,8 @@ commands:
     description: 'Install flutter dependencies'    
     steps:            
       - flutter/install_sdk_and_pub:
-          version: 3.7.11
-          cache-version: v3
+          version: 3.13.0
+          cache-version: v4
   setup_gems:
     description: 'Install gem dependencies'
     parameters:

--- a/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/FlutterElementTargetingStrategy.kt
@@ -81,11 +81,19 @@ internal class FlutterElementTargetingStrategy(val plugin: AppcuesFlutterPlugin)
             val displayMetrics = it.context.resources.displayMetrics
             val density = displayMetrics.density
 
+            // get the root level window insets, which will be used to apply a height correction below
+            val insets = ViewCompat.getRootWindowInsets(it)?.getInsets(WindowInsetsCompat.Type.systemBars())
+                ?: Insets.NONE
+
+            // the capture from the FlutterRenderer contains the top system bar but not the bottom
+            // so bottom is subtracted from the layout height
+            val height = (actualPosition.height() - insets.bottom).toDp(density)
+
             return ViewElement(
                 x = actualPosition.left.toDp(density),
                 y = actualPosition.top.toDp(density),
                 width = actualPosition.width().toDp(density),
-                height = actualPosition.height().toDp(density),
+                height = height,
                 selector = null,
                 displayName = null,
                 type = this.javaClass.name,

--- a/doc/AnchoredTooltips.md
+++ b/doc/AnchoredTooltips.md
@@ -10,11 +10,16 @@ The Semantics information allows the Appcues Flutter plugin to create a mobile v
 
 Appcues anchored tooltip support in Flutter uses a listener for Semantics tree updates, using the PipelineOwner [ensureSemantics](https://api.flutter.dev/flutter/rendering/PipelineOwner/ensureSemantics.html) method. Usage of this feature is optional. To enable anchored tooltip support call:
 ```dart
+var handle = SemanticsBinding.instance.ensureSemantics(); // only required if using Flutter 3.16+
 Appcues.enableElementTargeting();
 ```
 
+> [!IMPORTANT]
+> If using Flutter 3.16 or above, the additional SemanticsBinding call shown above is required, due to changes in how the Flutter SDK generates the Semantics updates.
+
 If it is necessary to disable this feature in any section of an application, call:
 ```dart
+handle.dispose(); // if using Flutter 3.16+
 Appcues.disableElementTargeting();
 ```
 

--- a/example/lib/src/screens/events.dart
+++ b/example/lib/src/screens/events.dart
@@ -31,10 +31,8 @@ class EventsScreen extends StatelessWidget {
                   tagForChildren: const AppcuesView("btnEvent1"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {
@@ -49,10 +47,8 @@ class EventsScreen extends StatelessWidget {
                   tagForChildren: const AppcuesView("btnEvent2"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {

--- a/example/lib/src/screens/group.dart
+++ b/example/lib/src/screens/group.dart
@@ -39,10 +39,8 @@ class _GroupScreenState extends State<GroupScreen> {
                   tagForChildren: const AppcuesView("btnSaveGroup"),
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      // Foreground color
-                      onPrimary: Theme.of(context).colorScheme.onPrimary,
-                      // Background color
-                      primary: Theme.of(context).colorScheme.primary,
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
                       minimumSize: const Size.fromHeight(44),
                     ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                     onPressed: () async {

--- a/example/lib/src/screens/profile.dart
+++ b/example/lib/src/screens/profile.dart
@@ -62,10 +62,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 tagForChildren: const AppcuesView("btnSaveProfile"),
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    // Foreground color
-                    onPrimary: Theme.of(context).colorScheme.onPrimary,
-                    // Background color
-                    primary: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
                     minimumSize: const Size.fromHeight(44),
                   ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                   onPressed: () async {

--- a/example/lib/src/screens/sign_in.dart
+++ b/example/lib/src/screens/sign_in.dart
@@ -51,10 +51,8 @@ class _SignInScreenState extends State<SignInScreen> {
                 padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    // Foreground color
-                    onPrimary: Theme.of(context).colorScheme.onPrimary,
-                    // Background color
-                    primary: Theme.of(context).colorScheme.primary,
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
                     minimumSize: const Size.fromHeight(44),
                   ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
                   onPressed: () async {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.1.2"
+    version: "3.1.3"
   async:
     dependency: transitive
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -98,14 +98,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   lints:
     dependency: transitive
     description:
@@ -118,18 +110,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -155,10 +147,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -195,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -207,6 +199,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=2.5.0"

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -346,8 +346,13 @@ class Appcues {
           // into global coordinates for the screen.
           Rect transformToRoot(Rect rect, SemanticsNode? node) {
             var transform = node?.transform;
+            var parent = node?.parent;
             if (transform == null) {
-              return rect;
+              if (parent != null) {
+                return transformToRoot(rect, parent);
+              } else {
+                return rect;
+              }
             }
 
             var transformed = rect;
@@ -356,7 +361,7 @@ class Appcues {
               transformed = rect.shift(offset);
             }
 
-            return transformToRoot(transformed, node?.parent);
+            return transformToRoot(transformed, parent);
           }
 
           // do the transform to global coordinates


### PR DESCRIPTION
As discussed in https://github.com/appcues/appcues-flutter-plugin/pull/60, the way that Semantics updates are processed changed in Flutter 3.16+ . Rather than modify our SDK at this point, we'll maintain the deprecated code for maximum backwards compatibility (for now), and provide a documentation update with the one line of code necessary to use element targeting with newer versions of the Flutter SDK.

The other changes here are mostly cosmetic, to ensure that the screen capture confirmation dialog selector preview all looks as expected - fixing a small display issue we had previously.

Updated our build configuration to use a more recent Flutter 3.13 version for the example app build (but not latest 3.16 yet)
![Screenshot 2023-11-30 at 2 18 39 PM](https://github.com/appcues/appcues-flutter-plugin/assets/19266448/6a62baed-6a72-4fd1-9037-2dc6dfce7bf9)
