### PR TITLE
Update release script for publish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -110,5 +110,5 @@ gh release create $newVersion -F $releaseTempFile -t $newVersion
 rm $releaseTempFile
 rm $changelogTempFile
 
-# dart pub publish
-dart pub publish
+# publish to pub.dev
+flutter pub publish


### PR DESCRIPTION
This seems like a required change after I updated to a more recent Flutter version (3.13.0 locally) - the previous script failed locally the first time with the error: 
```
Flutter users should use `flutter pub` instead of `dart pub`.
```