### PR TITLE
🐛 Fix Embeds on RTL

### DIFF
--- a/android/src/main/kotlin/com/appcues/flutter/AppcuesFrameViewFactory.kt
+++ b/android/src/main/kotlin/com/appcues/flutter/AppcuesFrameViewFactory.kt
@@ -56,7 +56,7 @@ internal class AppcuesWrapperView(context: Context) : FrameLayout(context) {
     var eventChannel: EventChannel? = null
         set(eventChannel) {
             field = eventChannel
-            eventChannel?.setStreamHandler(object: EventChannel.StreamHandler {
+            eventChannel?.setStreamHandler(object : EventChannel.StreamHandler {
                 override fun onListen(arguments: Any?, events: EventSink?) {
                     eventSink = events
                 }
@@ -82,6 +82,8 @@ internal class AppcuesWrapperView(context: Context) : FrameLayout(context) {
             MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY)
         )
         layout(left, top, right, bottom)
+        // ensure that when we measure/layout we schedule a invalidate for the next loop for a re-draw
+        postInvalidate()
     }
 
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {


### PR DESCRIPTION
addressing this [issue](https://appcues.slack.com/archives/C031RLGS4F8/p1707490603170929), customer is unable to see embeds in their App, they are on Flutter(Android) and their layout is set to RTL (right to left), by debugging this i noticed that  similar to what happened recently on react native, it seems like the composition is losing state somewhere between layout passes, probably because there are extra updates to LayoutDirection coming of compose, besides that the view wrapper we have on the flutter side needs to re-draw to ensure that its drawing after changing width/height.

postInvalidate ensures that after the measure and layout we schedule a draw step on the next UI thread cycle.