### PR TITLE
Fix issue with translating view coordinates from local to global

### DIFF
--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -359,6 +359,21 @@ class Appcues {
             var offset = MatrixUtils.getAsTranslation(transform);
             if (offset != null) {
               transformed = rect.shift(offset);
+            } else {
+              // If for some reason getAsTranslation fails to provide an offset
+              // but it is not a scale transform, then fall back to doing
+              // a transform on the top left point of the rect. This is a
+              // workaround to an observed issue with some layout structures.
+              if (MatrixUtils.getAsScale(transform) == null &&
+                  !MatrixUtils.isIdentity(transform)) {
+                var topLeft =
+                MatrixUtils.transformPoint(transform, rect.topLeft);
+                transformed = Rect.fromLTRB(
+                    topLeft.dx,
+                    topLeft.dy,
+                    topLeft.dx + rect.size.width,
+                    topLeft.dy + rect.size.height);
+              }
             }
 
             return transformToRoot(transformed, parent);


### PR DESCRIPTION
The observed issue here was that, prior to this change, this type of FAB view hierarchy would result in an incorrect layout capture for anchored tooltips, for the tagged `"view-tag"` element - putting the FAB element at origin (0,0) in the top left of the view, rather than actual position.

```dart
      floatingActionButton: Padding(
          padding: const EdgeInsets.only(top: 40.0),
          child: Visibility(
              visible: true,
              child: Semantics(
                  tagForChildren: const AppcuesView("view-tag"),
                  child: FloatingActionButton.extended(
                    onPressed: () {},
                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
                    backgroundColor: Theme.of(context).colorScheme.primary,
                    label: const Text("Label"),
                    icon: const Icon(Icons.plus_one),
                  ))))
```

interestingly, it appeared that a much simpler structure with no wrapping elements, and Semantics applied directly to the child label, like below, could work in some scenarios:

```dart
      floatingActionButton: FloatingActionButton.extended(
        onPressed: () {},
        foregroundColor: Theme.of(context).colorScheme.onPrimary,
        backgroundColor: Theme.of(context).colorScheme.primary,
        label: Semantics(
            tagForChildren: const AppcuesView("view-tag"),
            child: const Text("Label")),
        icon: const Icon(Icons.plus_one),
      )
```

further debugging showed that the view coordinate transformation logic was hitting issues with some of the parent views matrix transforms, and the underlying reason is not totally clear still. By adding the changes in this PR, it allows a failed translation to fall back to transforming the top-left origin of the view rect and still being able to translate it into the parent coordinate system.

Also referenced the Flutter source [here](https://chromium.googlesource.com/external/github.com/flutter/flutter/+/refs/tags/v1.14.6/packages/flutter/lib/src/semantics/semantics.dart#2185) for some guidance and ideas.