### PR TITLE
Fix embed sizing issue on Android

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Appcues (4.0.0)
-  - appcues_flutter (4.0.0-beta.1):
+  - appcues_flutter (4.0.0):
     - Appcues (~> 4.0.0)
     - Flutter
   - AppcuesNotificationService (4.0.0)
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Appcues: caa6e170fbc97c2bd138d30337fa57b13354af6f
-  appcues_flutter: 24528bdc60ab9c4e31be862eff0e9e2c45e30d00
+  appcues_flutter: 958035083b54a31c3dc94119c35915d35aef89be
   AppcuesNotificationService: 472be2ad9c0578c4ad986c949bc611c021f7f90c
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.0-beta.1"
+    version: "4.0.0"
   async:
     dependency: transitive
     description:
@@ -98,6 +98,30 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -110,34 +134,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -199,14 +223,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "13.0.0"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
+  dart: ">=3.2.0-0 <4.0.0"
   flutter: ">=2.5.0"

--- a/lib/appcues_flutter.dart
+++ b/lib/appcues_flutter.dart
@@ -102,8 +102,8 @@ class _AppcuesFrameViewState extends State<AppcuesFrameView> {
   // layoutSubviews is called at least once. Then, the intrinsic size of
   // the native view will control the SizedBox dimensions here to auto
   // size contents or set to zero if hidden.
-  double _height = 0.1;
-  double _width = 0.1;
+  double _height = 1;
+  double _width = 1;
   StreamSubscription? _sizeStream;
 
   @override


### PR DESCRIPTION
Customer reported issue, Android embeds do not render correctly in the Flutter plugin, and an error is shown in logcat:

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: PlatformException(error, The image dimensions must be positive, null, java.lang.IllegalArgumentException: The image dimensions must be positive
at android.media.ImageReader.initializeImageReader(ImageReader.java:319)
at android.media.ImageReader.<init>(ImageReader.java:363)
at android.media.ImageReader.<init>(Unknown Source:0)
at android.media.ImageReader$Builder.build(ImageReader.java:1093)
at io.flutter.plugin.platform.ImageReaderPlatformViewRenderTarget.createImageReader33(ImageReaderPlatformViewRenderTarget.java:70)
at io.flutter.plugin.platform.ImageReaderPlatformViewRenderTarget.createImageReader(ImageReaderPlatformViewRenderTarget.java:90)
at io.flutter.plugin.platform.ImageReaderPlatformViewRenderTarget.resize(ImageReaderPlatformViewRenderTarget.java:114)
at io.flutter.plugin.platform.PlatformViewWrapper.resizeRenderTarget(PlatformViewWrapper.java:86)
at io.flutter.plugin.platform.PlatformViewsController.configureForTextureLayerComposition(PlatformViewsController.java:626)
at io.flutter.plugin.platform.PlatformViewsController$1.createForTextureLayer(PlatformViewsController.java:234)
at io.flutter.embedding.engine.systemchannels.PlatformViewsChannel$1.create(PlatformViewsChannel.java:128)
at io.flutter.embedding.engine.systemchannels.PlatformViewsChannel$1.onMethodCall(PlatformViewsChannel.java:55)
at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:267)
at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(Unknown Source:12)
at android.os.Handler.handleCallback(Handler.java:958)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loopOnce(Looper.java:205)
at android.os.Looper.loop(Looper.java:294)
at android.app.ActivityThread.main(ActivityThread.java:8177)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```

I'm not sure when something changed here, but it seems that using size of `0.1` for initial height/width is no longer valid on Android. This size must be `1` initially. Then, the platform view auto sizing takes over and resets the size as needed.