### PR TITLE
Update Android SDK to 4.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,8 @@ commands:
     description: 'Install flutter dependencies'    
     steps:            
       - flutter/install_sdk_and_pub:
-          version: 3.13.0
-          cache-version: v4
+          version: 3.16.0
+          cache-version: v5
   setup_gems:
     description: 'Install gem dependencies'
     parameters:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This Plugin package is a bridge between the native Appcues SDKs in a Flutter app
 ### Prerequisites
 
 #### Android
-Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+
+Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+, and use Android Gradle Plugin (AGP) 8+.
 ```
 android {
     compileSdkVersion 34

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.appcues.flutter.sdk'
 version '4.0.0'
 
 buildscript {
-    ext.kotlin_version = '1.6.20'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -47,5 +47,5 @@ android {
 }
 
 dependencies {
-    api 'com.appcues:appcues:4.0.0'
+    api 'com.appcues:appcues:4.0.3'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,22 +1,13 @@
-def localProperties = new Properties()
-def localPropertiesFile = rootProject.file('local.properties')
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.withReader('UTF-8') { reader ->
-        localProperties.load(reader)
-    }
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+    id "com.google.gms.google-services"
 }
-
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
-
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply plugin: 'com.google.gms.google-services'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.appcues.samples.flutter"
+
     compileSdk 34
 
     compileOptions {
@@ -42,9 +33,7 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now,
-            // so `flutter run --release` works.
+            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }
@@ -52,8 +41,4 @@ android {
 
 flutter {
     source '../..'
-}
-
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.appcues.samples.flutter">
+    xmlns:tools="http://schemas.android.com/tools">
    <application
         android:label="Appcues Flutter Example"
         android:name="${applicationName}"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,17 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.20'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.google.gms:google-services:4.4.1'
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,4 +1,3 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
-shrink=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,11 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.0.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.google.gms.google-services" version "4.4.1" apply false
+}
+
+include ":app"


### PR DESCRIPTION
This also required modernizing some of our example app project settings to be able to use the newer dependencies within the updated SDK. Specifically moved kotlin up to 1.8.22 and the Android Gradle Plugin (AGP) to version 8. Some customers may face a similar required version updates.