### PR TITLE
Fix special case rendering of embeds on iOS

### DIFF
--- a/ios/Classes/Embeds/AppcuesFrameViewFactory.swift
+++ b/ios/Classes/Embeds/AppcuesFrameViewFactory.swift
@@ -110,7 +110,8 @@ class WrapperView: UIView, FlutterStreamHandler {
     }
 
     func setIntrinsicSize(preferredContentSize: CGSize, isHidden: Bool) {
-        let size = isHidden ? .zero : preferredContentSize
+        // The height cannot be 0 otherwise the view might be removed
+        let size = isHidden ? CGSize(width: 0, height: 0.01) : preferredContentSize
 
         eventSink?([
             "height": size.height,


### PR DESCRIPTION
When the `AppcuesFrameView` is the first child of a `ListView`, it wasn’t rendering because setting the height to 0 resulted in the view being removed from the native view hierarchy.