### PR TITLE
Update native SDK dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ This Plugin package is a bridge between the native Appcues SDKs in a Flutter app
 ### Prerequisites
 
 #### Android
-Your application's `build.gradle` must have a `compileSdkVersion` of 34+ and `minSdkVersion` of 21+, and use Android Gradle Plugin (AGP) 8+.
+Your application's `build.gradle` must have a `compileSdk` of 35+ and `minSdk` of 21+, and use Android Gradle Plugin (AGP) 8.1+.
 ```
 android {
-    compileSdkVersion 34
+    compileSdk 35
 
     defaultConfig {
-        minSdkVersion 21
+        minSdk 21
     }
 }
 ```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -47,5 +47,5 @@ android {
 }
 
 dependencies {
-    api 'com.appcues:appcues:4.3.7'
+    api 'com.appcues:appcues:4.3.9'
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace "com.appcues.samples.flutter"
 
-    compileSdk 34
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.0.2" apply false
+    id "com.android.application" version '8.1.0' apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
     id "com.google.gms.google-services" version "4.4.1" apply false
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -36,7 +36,7 @@ end
 NSE = 'AppcuesNotificationServiceExtension'
 target NSE do
   use_frameworks!
-  pod 'AppcuesNotificationService', '4.3.8'
+  pod 'AppcuesNotificationService', '4.3.9'
 end
 
 post_install do |installer|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Appcues (4.3.8)
-  - appcues_flutter (4.3.4):
-    - Appcues (~> 4.3.8)
+  - Appcues (4.3.9)
+  - appcues_flutter (4.3.5):
+    - Appcues (~> 4.3.9)
     - Flutter
-  - AppcuesNotificationService (4.3.8)
+  - AppcuesNotificationService (4.3.9)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
   - appcues_flutter (from `.symlinks/plugins/appcues_flutter/ios`)
-  - AppcuesNotificationService (= 4.3.8)
+  - AppcuesNotificationService (= 4.3.9)
   - Flutter (from `Flutter`)
 
 SPEC REPOS:
@@ -23,11 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  Appcues: 5cd95ab2abbfd0fba7b6df990563f1214d928e3f
-  appcues_flutter: 2f1596a5954ae091a281c324234f58e9ffe0e87a
-  AppcuesNotificationService: 6440cf291e032fbc22bae8794ef4edb98abdf305
+  Appcues: c539f8b09b0ba42627b6016887c520a194c7afbc
+  appcues_flutter: 8258a05adb79ce17a3cd8411f6851279be10c398
+  AppcuesNotificationService: 98d34473e60b8d023769cb9f636e3b3a42a7fb11
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
-PODFILE CHECKSUM: 6e2c93ca809cc0ed5f5ba86431607be036c0aca2
+PODFILE CHECKSUM: cceabda767a0b27264caf51f5c30f118449de14e
 
 COCOAPODS: 1.16.2

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,15 +23,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.3.4"
+    version: "4.3.5"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -76,10 +76,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -102,10 +102,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -227,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/appcues_flutter.podspec
+++ b/ios/appcues_flutter.podspec
@@ -11,7 +11,7 @@ A plugin package for sending user properties and events to the Appcues API and r
   s.source = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Appcues', '~> 4.3.8'
+  s.dependency 'Appcues', '~> 4.3.9'
   s.platform = :ios, '11.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
Pickup recent updates in native repos
* iOS 4.3.9
* Android 4.3.9

Note: Android update also requires bump to `compileSdk: 35` and AGP `8.1.0`+